### PR TITLE
Update to 1.5.5-8.0 dotnet for docker image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/dotnet:1-8.0-bookworm as base
+FROM mcr.microsoft.com/devcontainers/dotnet:1.5.5-8.0-bookworm as base
 
 # install additional OS packages.
  RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/dotnet:1.5.5-8.0-bookworm as base
+FROM mcr.microsoft.com/dotnet/sdk:8.0 as base
 
 # install additional OS packages.
  RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
check if the new version does not have the gpg key expired issue